### PR TITLE
Fix id, name and description

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "packaging_format": 1,
     "description": {
         "en": "A lightweight wiki-style CMS using the txt2tags syntax",
-        "fr": "Un CMS géré sous forme de wiki utilisant la syntaxe txt2tags"
+        "fr": "Un CMS léger, géré sous forme de wiki utilisant la syntaxe txt2tags"
     },
     "version": "1.0~ynh1",
     "url": "https://lionwiki-t2t.sourceforge.io/",

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-    "name": "Wiki",
-    "id": "lionwikit2t",
+    "name": "Lionwiki",
+    "id": "lionwiki-t2t",
     "packaging_format": 1,
     "description": {
-        "en": "Lionwiki-t2t is a simple CMS (content management system) in the form of a wiki engine, based on lionwiki and the txt2tags syntax, and using flat files as database.",
-        "fr": "Lionwiki-t2t est un système CMS de type wiki pour la création et l'entretien collectif de sites internet, utilisant des fichiers textes comme base de données."
+        "en": "A lightweight wiki-style CMS using the txt2tags syntax",
+        "fr": "Un CMS géré sous forme de wiki utilisant la syntaxe txt2tags"
     },
     "version": "1.0~ynh1",
     "url": "https://lionwiki-t2t.sourceforge.io/",


### PR DESCRIPTION
- "Wiki" probably aint the real name ;) ? So let's change this to Lionwiki for example (or LionwikiT2t or idk which name you'd like exactly)
- It really prevent many super weird issues if you stay consistent between the id in the manifest, the name of the repo, and key in apps.json ... so let's stick to `lionwiki-t2t` with a dash
- Description is meant to be displayed in tiles like in https://yunohost.org/apps and app catalog in the webadmin and therefore gotta stay short on concise